### PR TITLE
Make leveling up faster

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -66,7 +66,7 @@ export default class RPG extends Plugin {
   updateStats() {
     this.fileCount = this.app.vault.getFiles().length;
     const totalXP = this.settings.xp + (this.fileCount * this.settings.xpPerFile);
-    const currentLevel = Math.floor(Math.sqrt(Math.max(totalXP, 0) / 600)) + 1;
+    const currentLevel = Math.floor(Math.sqrt(Math.max(totalXP, 0) / 100)) + 1;
     if (currentLevel > this.settings.level) {
       this.settings.level = currentLevel;
       new Notice(`You leveled up to level ${currentLevel}!`);


### PR DESCRIPTION
I have over 16,000 XP and I only reached level 5 instead of level greater than 10, so I adjusted the level formula to make leveling up faster.